### PR TITLE
Fixed capitalization of sirupsen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vladoatanasov/logrus_amqp"
 )
 

--- a/logrus_amqp.go
+++ b/logrus_amqp.go
@@ -3,7 +3,7 @@ package logrus_amqp
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 )
 

--- a/logrus_amqp_test.go
+++ b/logrus_amqp_test.go
@@ -3,7 +3,7 @@ package logrus_amqp
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
The Sirupsen import was causing problems when resolving dependencies on case-sensitive file systems like MacOS.
